### PR TITLE
Pass block to Tilt's render to allow yield in templates

### DIFF
--- a/lib/sho/configurator.rb
+++ b/lib/sho/configurator.rb
@@ -113,12 +113,12 @@ module Sho
 
     def define_template_method(name, tilt, mandatory, optional, layout)
       arguments = ArgumentValidator.new(*mandatory, **optional)
-      @host.__send__(:define_method, name) do |**locals|
+      @host.__send__(:define_method, name) do |**locals, &block|
         locals = arguments.call(**locals)
         if layout
           __send__(layout) { tilt.render(self, **locals) }
         else
-          tilt.render(self, **locals)
+          tilt.render(self, **locals, &block)
         end
       end
     end

--- a/spec/sho/configurator_spec.rb
+++ b/spec/sho/configurator_spec.rb
@@ -90,6 +90,18 @@ RSpec.describe Sho::Configurator do
 
           it { is_expected.to eq 'before <p>It works!</p> after' }
         end
+
+        describe 'layout from template' do
+          let(:args) { [_layout: :laymeout] }
+
+          before {
+            sho.inline_template :laymeout, erb: <<~ERB.strip
+              before <%= yield %> after
+            ERB
+          }
+
+          it { is_expected.to eq 'before <p>It works!</p> after' }
+        end
       end
     end
 


### PR DESCRIPTION
Without passing the block, we end up with a `LocalJumpError` when `yield` is called inside a template created using one of the template helpers.