### PR TITLE
Allow caching to be configurable

### DIFF
--- a/spec/sho/configurator_spec.rb
+++ b/spec/sho/configurator_spec.rb
@@ -119,6 +119,23 @@ RSpec.describe Sho::Configurator do
 
       it { is_expected.to eq '<p>It works!</p>' }
     end
+
+    context 'with cache disabled' do
+      subject { object }
+
+      before {
+        sho.cache = false
+        sho.template :test, 'fake.slim', *args
+      }
+      let(:params) { {} }
+      let(:path) { 'fake.slim' }
+
+      it {
+        expect(subject.test).to eq '<p>It works!</p>'
+        File.write(path, 'p No cache!')
+        expect(subject.test).to eq '<p>No cache!</p>'
+      }
+    end
   end
 
   describe '#template_relative' do


### PR DESCRIPTION
Adds a `sho.cache` attribute accessor (defaulting to `true`) that allows the disabling of caching.

Only works for file based templates - I'm not really sure how it would work for an inline template, or if it would even be necessary.

I'm not sure what the performance hit will be on calling `respond_to?` each time the method is called. Might be worth optimizing it further by making it always callable, but that might have it's own issues :smile: